### PR TITLE
Add doc about adding middleware for debug_toolbar

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,14 +84,11 @@ If you really need the assets, ask Zopieux.
 ### Development setup
 
 * *Django Debug Toolbar* is here to help; you can use it by adding the
-  following line to your settings:
+  following lines to your settings:
 
         :::python
         INSTALLED_APPS += ('debug_toolbar',)
-   
-  You also need to add a middleware:
-
-        :::python
+	
         MIDDLEWARE += ('debug_toolbar.middleware.DebugToolbarMiddleware',)
    
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,12 @@ If you really need the assets, ask Zopieux.
 
         :::python
         INSTALLED_APPS += ('debug_toolbar',)
+   
+  You also need to add a middleware:
+
+        :::python
+        MIDDLEWARE += ('debug_toolbar.middleware.DebugToolbarMiddleware',)
+   
 
 * By default a SQLite3 (file based) database is used. Disclaimer: this is
   convenient but *performance is poor*. It is thus recommended to setup a local


### PR DESCRIPTION
Fixes the following error :

```
SystemCheckError: System check identified some issues:

ERRORS:
?: debug_toolbar.middleware.DebugToolbarMiddleware is missing from MIDDLEWARE.
	HINT: Add debug_toolbar.middleware.DebugToolbarMiddleware to MIDDLEWARE.
```