### PR TITLE
Add instruction to the venv installation procedure

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ It is recommended to use a virtualenv to isolate Prologin Python environment.
     # Do this once!
     python3 -m venv .venv
     source .venv/bin/activate
+    pip install --upgrade pip # fixes some package conflicts with old pip versions
     pip install -r requirements.txt
 
 ## Configuration


### PR DESCRIPTION
Update venv pip before installing the requirements. With older versions of pip, some package version conflicts occur.
Fixed in pip 18.0 "Improve handling of PEP 518 build requirements: support environment markers and extras. (#5230, #5265)"