### PR TITLE
problems: warn for integer named testcases

### DIFF
--- a/prologin/problems/views.py
+++ b/prologin/problems/views.py
@@ -215,15 +215,19 @@ class Problem(PermissionRequiredMixin, CreateView):
         #   case section, a warning is displayed to staff members if there is
         #   one.
         if self.request.user.is_staff:
+            integer_names = []
+
             for test in problem.tests:
                 if test.name.isdigit():
-                    messages.add_message(
-                        self.request, messages.WARNING,
-                        'Some testcase names are integers. This may be an issue'
-                        ' while parsing <em>problem.props</em>, so you should'
-                        ' consider renaming.'
-                    )
-                    break
+                    integer_names.append(test.name)
+
+            if integer_names:
+                messages.add_message(
+                    self.request, messages.WARNING,
+                    'Some testcase names are integers. This may be an issue'
+                    ' while parsing <em>problem.props</em>, so you should'
+                    ' consider renaming <strong>%s</strong>.' % ', '.join(integer_names)
+                )
 
         tackled_by = list(problems.models.Submission.objects.filter(challenge=challenge.name,
                                                                     problem=problem.name))

--- a/prologin/problems/views.py
+++ b/prologin/problems/views.py
@@ -222,11 +222,12 @@ class Problem(PermissionRequiredMixin, CreateView):
                     integer_names.append(test.name)
 
             if integer_names:
+                names_str = ', '.join(integer_names)
                 messages.add_message(
                     self.request, messages.WARNING,
                     'Some testcase names are integers. This may be an issue'
                     ' while parsing <em>problem.props</em>, so you should'
-                    ' consider renaming <strong>%s</strong>.' % ', '.join(integer_names)
+                    ' consider renaming <strong>{}</strong>.'.format(names_str)
                 )
 
         tackled_by = list(problems.models.Submission.objects.filter(challenge=challenge.name,


### PR DESCRIPTION
Using an integer as a name for a testcase can lead to unexpected behaviors while parsing problem.prop.
Thus, is should be unrecommended as long as the parser tries to cast values to integers.