### PR TITLE
stype: add a max width to images in problems statements and samples

### DIFF
--- a/prologin/prologin/static/css/prologin.css
+++ b/prologin/prologin/static/css/prologin.css
@@ -558,6 +558,11 @@ input[type=checkbox].task-list-item-checkbox {
   text-align: left;
 }
 
+.problem-statement img,
+.problem-samples img {
+    max-width: 100%;
+}
+
 .progress-bar-fixed {
   padding: 0 4px;
 }


### PR DESCRIPTION
Most images overflow out of the screen on mobile phones. Larger images would have the same behavior on regular screens.