### PR TITLE
requirements: markdown lower than 3.0, higher than 2.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -52,7 +52,7 @@ jinja2
 # XML parsing (eg. corrector communication)
 lxml
 # Markdown support
-markdown>=2.4
+markdown>=2.6,<3.0
 # msgpack (camisole results)
 msgpack-python
 # Image manipulation support, previously known as PIL


### PR DESCRIPTION
py-gfm requires a version lower than 3.0 and using 2.4 or 2.5 also appears to create issues during server setup.