### PR TITLE
problems/urls: add proper type hints to integers in URLs

### DIFF
--- a/prologin/problems/urls.py
+++ b/prologin/problems/urls.py
@@ -9,10 +9,10 @@ urlpatterns = [
 
     path('<int:year>/<type>/<problem>', problems.views.Problem.as_view(), name='problem'),
     path('<int:year>/<type>/<problem>/lang-template', problems.views.AjaxLanguageTemplate.as_view(), name='ajax-language-template'),
-    path('<int:year>/<type>/<problem>/<submission>', problems.views.SubmissionCode.as_view(), name='submission'),
+    path('<int:year>/<type>/<problem>/<int:submission>', problems.views.SubmissionCode.as_view(), name='submission'),
 
-    path('submission-corrected/<submission>', problems.views.AjaxSubmissionCorrected.as_view(), name='ajax-submission-corrected'),
-    path('submission-recorrect/<submission>', problems.views.RecorrectView.as_view(), name='submission-recorrect'),
+    path('submission-corrected/<int:submission>', problems.views.AjaxSubmissionCorrected.as_view(), name='ajax-submission-corrected'),
+    path('submission-recorrect/<int:submission>', problems.views.RecorrectView.as_view(), name='submission-recorrect'),
 
     path('manual', problems.views.ManualView.as_view(), name='manual'),
     path('search', problems.views.SearchProblems.as_view(), name='search'),


### PR DESCRIPTION
Prevents runtime server errors when encountering non-ints in deeper parts of the code.