### PR TITLE
forum: display newlines in the textarea after preview

### DIFF
--- a/prologin/forum/templates/forum/base.html
+++ b/prologin/forum/templates/forum/base.html
@@ -23,6 +23,9 @@
         popupButtonClasses: 'fa fa-smile-o'
       });
       window.emojiPicker.discover();
+
+      // Display newlines in the input area when previewing message
+      $('.emoji-wysiwyg-editor').css("white-space", "pre-wrap");
     });
   </script>
 {% endblock %}


### PR DESCRIPTION
After hitting the preview button in the forum, the all textarea is displayed as one line.