### PR TITLE
homepage: fix leaderboard not displayed for non-member users

### DIFF
--- a/prologin/homepage/templates/homepage/school-challenge-leaderboard.html
+++ b/prologin/homepage/templates/homepage/school-challenge-leaderboard.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 {% load rules %}
-{% has_perm 'contest.interschool.view_leaderboard' request.user as view_leaderboard %}
+{% has_perm 'contest.interschool.view_leaderboard' request.user request.current_edition as view_leaderboard %}
 {% if view_leaderboard %}
 <h2>{% trans "Inter-school challenge" %}</h2>
 


### PR DESCRIPTION
parameters for current edition was not specified when checking for permission to
display the leaderboard on home page