### PR TITLE
mailing: fix views creating new objects

### DIFF
--- a/prologin/mailing/views.py
+++ b/prologin/mailing/views.py
@@ -72,6 +72,9 @@ class CreateTemplateView(TemplateMixin, CreateView):
         template.save()
         return super(ModelFormMixin, self).form_valid(form)
 
+    def get_object(self):
+        return None # the template isn't in db yet
+
 
 class UpdateTemplateView(TemplateMixin, ObjectByIdMixin, UpdateView):
     def form_valid(self, form):
@@ -178,6 +181,9 @@ class CreateQueryView(QueryMixin, CreateView):
         query.save()
         return super(ModelFormMixin, self).form_valid(form)
 
+    def get_object(self):
+        return None # the query isn't in the db yet
+
 
 class UpdateQueryView(QueryMixin, ObjectByIdMixin, UpdateView):
     pass
@@ -262,6 +268,9 @@ class BatchCreateView(PermissionRequiredMixin, CreateView):
             email.send_task()
 
         return super().form_valid(form)
+
+    def get_object(self):
+        return None # the batch isn't in the db yet
 
 
 class BatchDetailView(PermissionRequiredMixin, ListView):


### PR DESCRIPTION
The default get_object method of reversion.views.RevisionMixin requires
an object to work with, yet it is used for views that will create an
object in the future.