### PR TITLE
site: contest: able to abandon regional event

### DIFF
--- a/prologin/contest/models.py
+++ b/prologin/contest/models.py
@@ -197,9 +197,11 @@ class Assignation(ChoiceEnum):
     not_assigned = 0
     ruled_out = 1
     assigned = 2
+    abandoned = 3  # was selected but abandoned before the event
     ugettext_noop("Not assigned")
     ugettext_noop("Ruled out")
     ugettext_noop("Assigned")
+    ugettext_noop("Abandoned")
 
 
 class LearnAboutContest(ChoiceEnum):
@@ -357,6 +359,10 @@ class Contestant(ExportModelOperationsMixin('contestant'), models.Model):
     @property
     def is_assigned_for_semifinal(self):
         return self.assignation_semifinal == Assignation.assigned.value
+
+    @property
+    def has_abandoned_semifinal(self):
+        return self.assignation_semifinal == Assignation.abandoned.value
 
     @property
     def is_ruled_out_for_semifinal(self):

--- a/prologin/users/templates/users/profile.html
+++ b/prologin/users/templates/users/profile.html
@@ -104,14 +104,17 @@
               <div class="panel-body">
                 <ul class="nav nav-stacked fa-ul">
                   <li><i class="fa fa-li fa-asterisk"></i> {% trans "Completed the qualification step" %}</li>
-                  {% if contestant.edition.qualification_corrected and contestant.is_assigned_for_semifinal %}
-                    <li class="text-success"><i
-                      class="fa fa-li fa-check"></i> {% trans "Selected for regional events" %}</li>
-                    {% if contestant.completed_semifinal %}
-                      <li><i class="fa fa-li fa-asterisk"></i> {% trans "Competed in the regional events" %}</li>
-                      {% if contestant.edition.semifinal_corrected and contestant.is_assigned_for_final %}
-                        <li class="text-success"><i class="fa fa-li fa-check"></i> {% trans "Selected for the final" %}
-                        </li>
+                  {% if contestant.edition.qualification_corrected %}
+                    {% if contestant.is_assigned_for_semifinal or contestant.has_abandoned_semifinal %}
+                      <li class="text-success"><i class="fa fa-li fa-check"></i> {% trans "Selected for regional events" %}</li>
+                      {% if contestant.has_abandoned_semifinal %}
+                        <li><i class="fa fa-li fa-asterisk"></i> {% trans "Abandoned the regional events" %}</li>
+                      {% endif %}
+                      {% if contestant.completed_semifinal %}
+                        <li><i class="fa fa-li fa-asterisk"></i> {% trans "Competed in the regional events" %}</li>
+                        {% if contestant.edition.semifinal_corrected and contestant.is_assigned_for_final %}
+                          <li class="text-success"><i class="fa fa-li fa-check"></i> {% trans "Selected for the final" %}</li>
+                        {% endif %}
                       {% endif %}
                     {% endif %}
                   {% endif %}


### PR DESCRIPTION
Ables to mark a candidate as "abandoned", thus we can keep track of who participates to a specific event without removing the information that the candidate was qualified on its profile.