### PR TITLE
forum: make sure we always handle post deletion properly

### DIFF
--- a/prologin/forum/__init__.py
+++ b/prologin/forum/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'forum.apps.ForumConfig'

--- a/prologin/forum/apps.py
+++ b/prologin/forum/apps.py
@@ -1,0 +1,8 @@
+from django.apps import AppConfig
+
+class ForumConfig(AppConfig):
+    name = 'forum'
+    verbose_name = 'Forum'
+
+    def ready(self):
+        import forum.signals

--- a/prologin/forum/models.py
+++ b/prologin/forum/models.py
@@ -259,13 +259,6 @@ class Post(ExportModelOperationsMixin('post'), models.Model):
         # Trigger the thread-level trackers update
         self.thread.update_trackers()
 
-    def delete(self, using=None):
-        if self.is_thread_head:
-            self.thread.delete()
-        else:
-            super().delete(using)
-            self.thread.update_trackers()
-
     def get_absolute_url(self):
         thread = self.thread
         page = (self.position - 1) // settings.FORUM_POSTS_PER_PAGE + 1

--- a/prologin/forum/signals.py
+++ b/prologin/forum/signals.py
@@ -1,0 +1,13 @@
+from django.db.models.signals import post_delete
+from django.dispatch import receiver
+from forum.models import Post
+
+
+@receiver(post_delete, sender=Post)
+def update_thread_on_post_deletion(sender, instance, using, **kwargs):
+    # post was deleted, so checking instance.is_thread_head won't work
+    if (not Post.objects.filter(thread=instance.thread).exists() or
+            instance.date_created < instance.thread.first_post.date_created):
+        instance.thread.delete()
+    else:
+        instance.thread.update_trackers()


### PR DESCRIPTION
When a post's deletion is triggered by its author being deleted, the
overriden `delete` method isn't getting called.

This was the cause of two bugs:

 - the first one (#206) where the thread's last post date wouldn't get
   updated properly

 - the second one where deleting a user who's the author of a thread
   wouldn't actually delete the thread, triggering a server crash when
   later trying to access this thread's data.

Fixes #206