### PR TITLE
forum: fallback to official picture if no avatar for staff

### DIFF
--- a/prologin/forum/templates/forum/thread_posts.html
+++ b/prologin/forum/templates/forum/thread_posts.html
@@ -89,8 +89,8 @@
                 </div>
                 <div class="col-sm-12 col-xs-5 post-author-avatar">
                   {% if post.is_visible %}
-                    {% if post.author.avatar %}
-                      <img class="avatar avatar-full" src="{{ post.author.avatar.url }}"
+                    {% if post.author.avatar_or_picture %}
+                      <img class="avatar avatar-full" src="{{ post.author.avatar_or_picture.url }}"
                            alt="{% blocktrans with post.author.username as username %}{{ username }}'s profile picture{% endblocktrans %}"/>
                     {% endif %}
                     {% if post.author.is_staff %}<span class="staff-flare"><i class="fa fa-star-o"></i> {% trans "Staff member" %}</span>{% endif %}

--- a/prologin/users/models.py
+++ b/prologin/users/models.py
@@ -215,6 +215,12 @@ class ProloginUser(
         return slugify("{}{}".format(self.first_name[:1], self.last_name))
 
     @property
+    def avatar_or_picture(self):
+        if self.avatar:
+            return self.avatar
+        return self.picture
+
+    @property
     def picture_or_avatar(self):
         if self.picture:
             return self.picture


### PR DESCRIPTION
This tackles #186

Rather than fallback on the official picture if no avatar is found, this prioritizes the official picture over the avatar for members of staff in the forum threads. (Which may be what's preferable anyway ? If not, I can add a `avatar_or_picture` property to the `ProloginUser` model instead)