### PR TITLE
centers: switch from Google maps to OpenStreetMaps

### DIFF
--- a/prologin/centers/templates/centers/map.html
+++ b/prologin/centers/templates/centers/map.html
@@ -86,12 +86,12 @@
             </td>
             <td>
               <a href="#center-{{ forloop.counter0 }}"
-                 onclick="google.maps.event.trigger(center_markers[{{ forloop.counter0 }}], 'click');">
+                 onclick="center_markers[{{ forloop.counter0 }}].openPopup();">
                 <i class="fa fa-map-marker"></i> {% trans "Show" %}</a>
             </td>
             {% localize off %}
               <td>
-                <a href="https://tools.wmflabs.org/geohack/geohack.php?params={{ center.coordinates }}">
+                <a href="https://www.openstreetmap.org/?mlat={{ center.lat }}&mlon={{ center.lng }}#map=16/{{ center.lat }}/{{ center.lng }}">
                   <i class="fa fa-globe"></i> {% trans "Full map" %}</a></td>
             {% endlocalize %}
           </tr>
@@ -104,62 +104,62 @@
 {% endblock %}
 
 {% block extra_script %}
-  <script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?key=AIzaSyDk9fzbgveZQ8zPLkbhopSbZYb3UNQUMCg"></script>
   <script type="text/javascript" src="{% static 'js/utils.js' %}"></script>
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.5.1/dist/leaflet.css"
+                         integrity="sha512-xwE/Az9zrjBIphAcBb3F6JVqxf46+CDLwfLMHloNu6KEQCAWi6HcDUbeOfBIptF7tcCzusKFjFw2yuvEpDL9wQ=="
+                         crossorigin=""/>
+  <script src="https://unpkg.com/leaflet@1.5.1/dist/leaflet.js"
+          integrity="sha512-GffPMF3RvMeYyc1LWMHtK8EbPv0iNZ8/oTtHPx9/cc2ILxQ+u905qIwdpULaqDkyBKgOaB57QTMg7ztg8Jm2Og=="
+          crossorigin=""></script>
+
   <script type="text/javascript">
     $(function () {
-      var $map = $('#map-canvas-wrap'), $mapCol = $('#map-canvas-col');
+      var mapElement = $('#map-canvas-wrap'), mapColElement = $('#map-canvas-col');
 
       function applyWidth() {
-        $map.css('width', $mapCol.width());
+        mapElement.css('width', mapColElement.width());
       }
 
       applyWidth();
-      $map.affix({
+      mapElement.affix({
         offset: {
-          top: $mapCol.offset().top - 20,
+          top: mapColElement.offset().top - 20,
           bottom: $('footer').outerHeight(true)
         }
       });
       $(window).resize(applyWidth);
     });
 
+    var map = L.map('map-canvas', {
+      center: [47, 32],
+      zoom: 5,
+      trackResize: false
+    });
+
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+    }).addTo(map);
+
     var center_markers = [];
-    function initialize() {
-      var bounds = new google.maps.LatLngBounds();
-      var infowindow = new google.maps.InfoWindow();
-      var map = new google.maps.Map(document.getElementById('map-canvas'), {
-        // options
-      });
+    function createMarker(lat, lng, title, description) {
+      var marker = L.marker([lat, lng], {
+        title: title
+      }).addTo(map).bindPopup(description);
 
-      function createMarker(lat, lng, title, description) {
-        var marker = new google.maps.Marker({
-          position: new google.maps.LatLng(lat, lng),
-          title: title,
-          map: map
-        });
-        bounds.extend(marker.position);
-        google.maps.event.addListener(marker, 'click', function () {
-          window.location.hash = 'map-canvas-wrap';
-          infowindow.setContent(description);
-          infowindow.open(map, marker);
-        });
-        center_markers.push(marker);
-      }
+      center_markers.push(marker);
+    };
 
-      var body;
-      {% localize off %}
-        {% for center in centers %}
-          {% if center.has_valid_geolocation %}
-            body = "<strong>{{ center.name|escapejs }}</strong><br>" +
-              "{{ center.address|title|escapejs }}" +
-              "<br>{{ center.postal_code|escapejs }} {{ center.city|title|escapejs }}";
-            createMarker({{ center.lat }}, {{ center.lng }}, "{{ center.name|escapejs }}", body);
-          {% endif %}
-        {% endfor %}
-      {% endlocalize %}
-      map.fitBounds(bounds);
-    }
-    google.maps.event.addDomListener(window, 'load', initialize);
+    var body;
+    {% localize off %}
+      {% for center in centers %}
+        {% if center.has_valid_geolocation %}
+          body = "<strong>{{ center.name|escapejs }}</strong><br>" +
+            "{{ center.address|title|escapejs }}" +
+            "<br>{{ center.postal_code|escapejs }} {{ center.city|title|escapejs }}";
+          createMarker({{ center.lat }}, {{ center.lng }}, "{{ center.name|escapejs }}", body);
+        {% endif %}
+      {% endfor %}
+    {% endlocalize %}
+
   </script>
 {% endblock %}


### PR DESCRIPTION
This commit replaces the embedded map in /center by an OSM one using the
Leaflet (https://leafletjs.com) library.

It also replaces the "Full map" button's destination by an
openstreetmap.org link.

Before | After
-------- | ------
![before_1](https://user-images.githubusercontent.com/2761682/60606403-9671db00-9dbb-11e9-874d-655ed5ffd1b0.png) | ![after_1](https://user-images.githubusercontent.com/2761682/60606499-c4efb600-9dbb-11e9-8f1f-bdf81dc58ae2.png)
![before_2](https://user-images.githubusercontent.com/2761682/60606522-cde08780-9dbb-11e9-9f77-03c13bf44ea4.png) | ![after_2](https://user-images.githubusercontent.com/2761682/60606531-d20ca500-9dbb-11e9-8d10-2817be091e4e.png)

