### PR TITLE
users: urlsafe_base64_encode now returns a string

### DIFF
--- a/prologin/users/views.py
+++ b/prologin/users/views.py
@@ -236,7 +236,7 @@ class PasswordResetView(AnonymousRequiredMixin, FormView):
             # a password marked as unusable
             if not user.has_usable_password() and not user.legacy_md5_password:
                 continue
-            uid = urlsafe_base64_encode(force_bytes(user.pk)).decode()
+            uid = urlsafe_base64_encode(force_bytes(user.pk))
             token = default_token_generator.make_token(user)
             url = absolute_site_url(self.request,
                                     reverse('users:password_reset_confirm', kwargs=dict(uidb64=uid, token=token)))


### PR DESCRIPTION
Prior to Django 2.2 it returned a byte string, as described here:

https://docs.djangoproject.com/en/2.2/ref/utils/#django.utils.http.urlsafe_base64_encode

We don't need to decode it to a real string anymore.