### PR TITLE
Fix passwords problems during demi export

### DIFF
--- a/prologin/documents/views.py
+++ b/prologin/documents/views.py
@@ -147,7 +147,7 @@ class SemifinalDataExportView(PermissionRequiredMixin, View):
         def iter_users():
             for contestant in contestants:
                 user = contestant.user
-                user.set_password(user.plaintext_password(event=event.id))
+                user.password = user.plaintext_password(event)
                 user.username = user.normalized_username
                 yield user
 


### PR DESCRIPTION
demi export was re-hashing the cleartext_passwords before generating json-ish export file. The passwords must be in cleartext to be treated by demi_bootstrap management command.