### PR TITLE
 celeryworker: Use special queue prolosite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ smtpserver:
 	python $(TOP)/smtp_debug.py --host $(SMTP_HOST) --port $(SMTP_PORT) --lag $(SMTP_LAG)
 
 celeryworker:
-	$(CELERY) -l debug -A prologin worker
+	$(CELERY) -l debug -A prologin worker -Q prolosite
 
 shell:
 	$(MANAGE) shell

--- a/prologin/prologin/settings/common.py
+++ b/prologin/prologin/settings/common.py
@@ -165,6 +165,9 @@ CELERY_ENABLE_UTC = True
 CELERY_RESULT_BACKEND = BROKER_URL  # also use redis to store the results
 CELERY_RESULT_PERSISTENT = True  # keep results on broker restart
 CELERY_TASK_RESULT_EXPIRES = 3600 * 12  # 12 hours
+CELERY_ROUTES = {
+    '*': {'queue': 'prolosite'},
+}
 
 # Emails
 


### PR DESCRIPTION
Use special queue prolosite for the celeryworker instead of default queue celery