### PR TITLE
Fix plaintext password

### DIFF
--- a/prologin/documents/base_views.py
+++ b/prologin/documents/base_views.py
@@ -181,7 +181,7 @@ class BaseSemifinalDocumentView(BaseDocumentView):
         event_contestants = collections.defaultdict(list)
         for contestant in self.contestants.order_by('assignation_semifinal_event__date_begin', *USER_LIST_ORDERING):
             event = contestant.assignation_semifinal_event
-            contestant.password = contestant.user.plaintext_password(event)
+            contestant.password = contestant.user.plaintext_password(event=event.id)
             event_contestants[event].append(contestant)
         return sorted(event_contestants.items(),
                       key=lambda pair: pair[0].date_begin)
@@ -216,7 +216,7 @@ class BaseFinalDocumentView(BaseDocumentView):
         contestants = list(self.contestants)
         event = self.final_event
         for contestant in contestants:
-            contestant.password = contestant.user.plaintext_password(event)
+            contestant.password = contestant.user.plaintext_password(event=event.id)
         return [(self.final_event, contestants)]
 
 

--- a/prologin/documents/views.py
+++ b/prologin/documents/views.py
@@ -147,7 +147,7 @@ class SemifinalDataExportView(PermissionRequiredMixin, View):
         def iter_users():
             for contestant in contestants:
                 user = contestant.user
-                user.password = user.plaintext_password(event)
+                user.set_password(user.plaintext_password(event=event.id))
                 user.username = user.normalized_username
                 yield user
 


### PR DESCRIPTION
The hash salt was based on the user language setting, meaning the event object would be converted either to:

'Prologin 2020: Regional event starting 2020-02-09 05:00:00+00:00 at ESAIP Angers'

Or the French version.