### PR TITLE
Add a try to catch exception thread does not exist

### DIFF
--- a/prologin/forum/signals.py
+++ b/prologin/forum/signals.py
@@ -1,13 +1,16 @@
 from django.db.models.signals import post_delete
 from django.dispatch import receiver
-from forum.models import Post
+from forum.models import Post,Thread
 
 
 @receiver(post_delete, sender=Post)
 def update_thread_on_post_deletion(sender, instance, using, **kwargs):
     # post was deleted, so checking instance.is_thread_head won't work
-    if (not Post.objects.filter(thread=instance.thread).exists() or
-            instance.date_created < instance.thread.first_post.date_created):
-        instance.thread.delete()
-    else:
-        instance.thread.update_trackers()
+    try:
+        if (not Post.objects.filter(thread=instance.thread).exists() or
+                instance.date_created < instance.thread.first_post.date_created):
+            instance.thread.delete()
+        else:
+            instance.thread.update_trackers()
+    except Thread.DoesNotExist:
+        pass

--- a/prologin/forum/signals.py
+++ b/prologin/forum/signals.py
@@ -5,8 +5,8 @@ from forum.models import Post,Thread
 
 @receiver(post_delete, sender=Post)
 def update_thread_on_post_deletion(sender, instance, using, **kwargs):
-    # post was deleted, so checking instance.is_thread_head won't work
     try:
+        # post was deleted, so checking instance.is_thread_head won't work
         if (not Post.objects.filter(thread=instance.thread).exists() or
                 instance.date_created < instance.thread.first_post.date_created):
             instance.thread.delete()


### PR DESCRIPTION
Without the try the, deleting the thread might not be possible because
of this "update_thread_on_post_deletion". And there is no need to delete
or update anything if the thread has allready been deleted.