### PR TITLE
final2020: change displayed date to temporary text

### DIFF
--- a/prologin/homepage/templates/homepage/homepage.html
+++ b/prologin/homepage/templates/homepage/homepage.html
@@ -21,7 +21,7 @@
   <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
   <i class="fa fa-exclamation-triangle"></i>
   <div>
-    <strong>{% trans 'Due to the sanitary crisis, the final date will be announced later. Please read the news for more information.' %}</strong>
+      <strong>{% blocktrans %}Due to the sanitary crisis, the final date will be announced later. Please read this <a href="https://prologin.org/news/A9S/">news</a> for more information.'{% endblocktrans %}</strong>
   </div>
 </div>
 

--- a/prologin/homepage/templates/homepage/homepage.html
+++ b/prologin/homepage/templates/homepage/homepage.html
@@ -21,7 +21,7 @@
   <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
   <i class="fa fa-exclamation-triangle"></i>
   <div>
-      <strong>{% blocktrans %}Due to the sanitary crisis, the final date will be announced later. Please read this <a href="https://prologin.org/news/A9S/">news</a> for more information.'{% endblocktrans %}</strong>
+      <strong>{% blocktrans %}Due to the sanitary crisis, the final date will be announced later. Please read this <a href="https://prologin.org/news/A9S/">news</a> for more information.{% endblocktrans %}</strong>
   </div>
 </div>
 

--- a/prologin/homepage/templates/homepage/homepage.html
+++ b/prologin/homepage/templates/homepage/homepage.html
@@ -14,7 +14,17 @@
 
 {% include "homepage/jumbotron.html" %}
 
+
 <div class="container">
+
+<div class="alert alert-dismissable alert-warning">
+  <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
+  <i class="fa fa-exclamation-triangle"></i>
+  <div>
+    <strong>{% trans 'Due to the sanitary crisis, the final date will be announced later. Please read the news for more information.' %}</strong>
+  </div>
+</div>
+
 
   {% include "prologin/messages.html" %}
 

--- a/prologin/homepage/templates/homepage/jumbotron-final.html
+++ b/prologin/homepage/templates/homepage/jumbotron-final.html
@@ -7,8 +7,9 @@
         <h4>{% trans "Final" %}</h4>
         <p class="date">
           {% if final.date_begin or final.date_end %}
-          {{ final.date_begin|date:"d b Y"|default:no_such_date }}
-          →&nbsp;{{ final.date_end|date:"d b Y"|default:no_such_date }}
+          <!--{{ final.date_begin|date:"d b Y"|default:no_such_date }}
+          →&nbsp;{{ final.date_end|date:"d b Y"|default:no_such_date }}-->
+            {% trans 'Due to the sanitary crisis, the final date will be announced later.' %}
           {% else %}
             {{ no_such_date }}
           {% endif %}

--- a/prologin/homepage/templates/homepage/jumbotron-final.html
+++ b/prologin/homepage/templates/homepage/jumbotron-final.html
@@ -7,11 +7,8 @@
         <h4>{% trans "Final" %}</h4>
         <p class="date">
           {% if final.date_begin or final.date_end %}
-          {% comment %}
           {{ final.date_begin|date:"d b Y"|default:no_such_date }}
           →&nbsp;{{ final.date_end|date:"d b Y"|default:no_such_date }}
-          {% endcomment %}
-            {% trans 'Due to the sanitary crisis, the final date will be announced later.' %}
           {% else %}
             {{ no_such_date }}
           {% endif %}

--- a/prologin/homepage/templates/homepage/jumbotron-final.html
+++ b/prologin/homepage/templates/homepage/jumbotron-final.html
@@ -7,8 +7,10 @@
         <h4>{% trans "Final" %}</h4>
         <p class="date">
           {% if final.date_begin or final.date_end %}
-          <!--{{ final.date_begin|date:"d b Y"|default:no_such_date }}
-          →&nbsp;{{ final.date_end|date:"d b Y"|default:no_such_date }}-->
+          {% comment %}
+          {{ final.date_begin|date:"d b Y"|default:no_such_date }}
+          →&nbsp;{{ final.date_end|date:"d b Y"|default:no_such_date }}
+          {% endcomment %}
             {% trans 'Due to the sanitary crisis, the final date will be announced later.' %}
           {% else %}
             {{ no_such_date }}

--- a/prologin/locale/fr/LC_MESSAGES/django.po
+++ b/prologin/locale/fr/LC_MESSAGES/django.po
@@ -23,12 +23,13 @@
 # Victor Collod <victor.collod@prologin.org>, 2016
 # Alexandre Macabies <web+transifex@zopieux.com>, 2015
 # Yves Stadler <mvyonline@gmail.com>, 2015
+# Valentin Seux <elfikur@prologin.org> 2020
 msgid ""
 msgstr ""
 "Project-Id-Version: Prologin website\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-04-05 17:01+0200\n"
-"PO-Revision-Date: 2020-04-05 14:08+0000\n"
+"POT-Creation-Date: 2020-04-15 18:16+0200\n"
+"PO-Revision-Date: 2020-04-15 18:17+0200\n"
 "Last-Translator: Antoine Pietri <antoine.pietri1@gmail.com>\n"
 "Language-Team: French (http://www.transifex.com/prologin/prologin-site/"
 "language/fr/)\n"
@@ -37,6 +38,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"X-Generator: Poedit 2.3\n"
 
 #: archives/templates/archives/finale-scoreboard.html:7
 #: archives/templates/archives/index.html:7
@@ -2088,31 +2090,41 @@ msgstr ""
 "monde de la programmation et de l'algorithmique aux étudiants et de les "
 "confronter à des problèmes classiques et des challenges excitants."
 
-#: homepage/templates/homepage/homepage.html:31
+#: homepage/templates/homepage/homepage.html:24
+msgid ""
+"Due to the sanitary crisis, the final date will be announced later. Please "
+"read this <a href=\"https://prologin.org/news/A9S/\">news</a> for more "
+"information."
+msgstr ""
+"A cause de la crise sanitaire, la date de la finale sera annoncée "
+"ultérieurement. Nous vous invitons à lire cet <a href=\"https://prologin.org/"
+"news/A9S/\">article</a> pour plus d'informations."
+
+#: homepage/templates/homepage/homepage.html:41
 msgid "Latest news"
 msgstr "Dernières actualités"
 
-#: homepage/templates/homepage/homepage.html:33
-#: homepage/templates/homepage/homepage.html:72
+#: homepage/templates/homepage/homepage.html:43
+#: homepage/templates/homepage/homepage.html:82
 msgid "Browse all news"
 msgstr "Consulter toutes les actualités"
 
-#: homepage/templates/homepage/homepage.html:43
+#: homepage/templates/homepage/homepage.html:53
 #: news/templates/zinnia/_entry_detail_base.html:19
 msgid "Written by"
 msgstr "Rédigé par"
 
-#: homepage/templates/homepage/homepage.html:47
+#: homepage/templates/homepage/homepage.html:57
 #: news/templates/zinnia/_entry_detail_base.html:23
 #, python-format
 msgid "Show all %(author)s's entries"
 msgstr "Tous les articles de %(author)s"
 
-#: homepage/templates/homepage/homepage.html:49
+#: homepage/templates/homepage/homepage.html:59
 msgid "on"
 msgstr "le"
 
-#: homepage/templates/homepage/homepage.html:51
+#: homepage/templates/homepage/homepage.html:61
 msgid "Written on"
 msgstr "Rédigé le"
 


### PR DESCRIPTION
Hello,

This PR is here because of the current sanitary events and the discrepancy between what we announced and what is displayed on the website.

It is a temporary hot fix to prevent people from thinking the final will go on as planned initially.
I believe there is no other reference to the final's date on the website, apart from the /about/contest/final, which we could change, but since we don't have a date at the moment, it doesn't make a lot of sense to do it.