### PR TITLE
about-gcc: adding gcc description in the about-organization page

### DIFF
--- a/prologin/pages/templates/pages/about-organization.html
+++ b/prologin/pages/templates/pages/about-organization.html
@@ -94,6 +94,24 @@ experiences for our staff members.</p>
 with us!</p>
 {% endblocktrans %}
 
+{% url 'pages:about-organization' as about_organization %}
+
+<h2 id="gcc">{% trans "Girls Can Code!" %}</h2>
+{% blocktrans %}<p class="text-justify">Prologin started to organize in 2014 the Girls Can Code! summer camps.
+These training camps are the perfect occasion for young girls who are still in middle school or in high school 
+to discover multiple computer science subjects throughout the week. They will learn how to solve problems with 
+algorithms, explore numerous material such as network, web development, robotics, microcontrollers, video games 
+and more through practical exercises.</p>
+
+<p class="text-justify">Conferences from exterior speakers are organized for every camp. It enables the attendees 
+to exchange with women working in the computer science industry or in research fields. The young girls are sometimes, 
+unsure as to what they want to do, this is a golden occasion for them to discuss with the speaker their educational 
+backgrounds, thus helping them for their orientation.</p>
+
+<p class="text-justify">Prologin's members are present during the camp to accompany them and to help them debug their 
+programs. More information can be found on Girls Can Code! <a href="https://gcc.prologin.org">website</a>.<br />For any 
+inquiries, please contact us <a href="{{ about_organization }}#contact">here</a>.</p>{% endblocktrans %}
+
   <h2 id="contribute">{% trans "Everyone can contribute to Prologin" %}</h2>
   {# TODO: link to forums; link to how to promote (posters) #}
   {% blocktrans %}<p class="text-justify">Contributing can be done in various ways: promoting the event, developing the website and

--- a/prologin/pages/templates/pages/about-organization.html
+++ b/prologin/pages/templates/pages/about-organization.html
@@ -98,20 +98,20 @@ with us!</p>
 
 <h2 id="gcc">{% trans "Girls Can Code!" %}</h2>
 <p class="text-justify">{% blocktrans %}In 2014, Prologin started to organize the Girls Can Code! summer camps.
-These training camps are the perfect occasion for young girls who are still in middle school or in high school 
-to discover multiple computer science subjects throughout the week. They will learn how to solve problems with 
-algorithms, explore various computer science topics such as network, web development, robotics, microcontrollers, video games 
+These training camps are the perfect occasion for young girls who are still in middle school or in high school
+to discover multiple computer science subjects throughout the week. They will learn how to solve problems with
+algorithms, explore various computer science topics such as network, web development, robotics, microcontrollers, video games
 and more through practical exercises.{% endblocktrans %}</p>
 
-<p class="text-justify">{% blocktrans %}Conferences from exterior speakers are organized for every camp. It enables the attendees 
-to exchange with women working in the computer science industry or in academia. The young girls are sometimes 
-unsure as to what they want to do, this is a golden occasion for them to discuss their education with the speaker, 
+<p class="text-justify">{% blocktrans %}Conferences from exterior speakers are organized for every camp. It enables the attendees
+to exchange with women working in the computer science industry or in academia. The young girls are sometimes
+unsure as to what they want to do, this is a golden occasion for them to discuss their education with the speaker,
 thus helping them for future orientation choices.{% endblocktrans %}</p>
 
-<p class="text-justify">{% blocktrans %}Prologin staff is present during the camp to help them debug their programs and pass on 
+<p class="text-justify">{% blocktrans %}Prologin staff is present during the camp to help them debug their programs and pass on
 knowledge in computer science and programming.{% endblocktrans %}</p>
 
-<p class="text-justify">{% blocktrans %}More information can be found on <a href="https://gcc.prologin.org">Girls Can Code! website</a>. For any 
+<p class="text-justify">{% blocktrans %}More information can be found on <a href="https://gcc.prologin.org">Girls Can Code! website</a>. For any
 inquiries, please <a href="{{ about_organization }}#contact">contact us</a>.{% endblocktrans %}</p>
 
   <h2 id="contribute">{% trans "Everyone can contribute to Prologin" %}</h2>

--- a/prologin/pages/templates/pages/about-organization.html
+++ b/prologin/pages/templates/pages/about-organization.html
@@ -97,22 +97,22 @@ with us!</p>
 {% url 'pages:about-organization' as about_organization %}
 
 <h2 id="gcc">{% trans "Girls Can Code!" %}</h2>
-{% blocktrans %}<p class="text-justify">Prologin started to organize in 2014 the Girls Can Code! summer camps.
+{% blocktrans %}<p class="text-justify">In 2014, Prologin started to organize the Girls Can Code! summer camps.
 These training camps are the perfect occasion for young girls who are still in middle school or in high school 
 to discover multiple computer science subjects throughout the week. They will learn how to solve problems with 
-algorithms, explore numerous material such as network, web development, robotics, microcontrollers, video games 
+algorithms, explore various computer science topics such as network, web development, robotics, microcontrollers, video games 
 and more through practical exercises.</p>
 
 <p class="text-justify">Conferences from exterior speakers are organized for every camp. It enables the attendees 
-to exchange with women working in the computer science industry or in research fields. The young girls are sometimes, 
-unsure as to what they want to do, this is a golden occasion for them to discuss with the speaker their educational 
-backgrounds, thus helping them for their orientation.</p>
+to exchange with women working in the computer science industry or in academia. The young girls are sometimes 
+unsure as to what they want to do, this is a golden occasion for them to discuss their education with the speaker, 
+thus helping them for future orientation choices.</p>
 
-<p class="text-justify">Prologin's members are present during the camp to accompany them and to help them debug their 
-programs and to help them understand key principles in computer science and programming.</p>
+<p class="text-justify">Prologin staff is present during the camp to help them debug their programs and pass on 
+knowledge in computer science and programming.</p>
 
-<p class="text-justify">More information can be found on Girls Can Code! <a href="https://gcc.prologin.org">website</a>. For any 
-inquiries, please contact us <a href="{{ about_organization }}#contact">here</a>.</p>{% endblocktrans %}
+<p class="text-justify">More information can be found on <a href="https://gcc.prologin.org">Girls Can Code! website</a>. For any 
+inquiries, please <a href="{{ about_organization }}#contact">contact us</a>.</p>{% endblocktrans %}
 
   <h2 id="contribute">{% trans "Everyone can contribute to Prologin" %}</h2>
   {# TODO: link to forums; link to how to promote (posters) #}

--- a/prologin/pages/templates/pages/about-organization.html
+++ b/prologin/pages/templates/pages/about-organization.html
@@ -111,7 +111,7 @@ backgrounds, thus helping them for their orientation.</p>
 <p class="text-justify">Prologin's members are present during the camp to accompany them and to help them debug their 
 programs and to help them understand key principles in computer science and programming.</p>
 
-<p class⁼"text-justify">More information can be found on Girls Can Code! <a href="https://gcc.prologin.org">website</a>. For any 
+<p class="text-justify">More information can be found on Girls Can Code! <a href="https://gcc.prologin.org">website</a>. For any 
 inquiries, please contact us <a href="{{ about_organization }}#contact">here</a>.</p>{% endblocktrans %}
 
   <h2 id="contribute">{% trans "Everyone can contribute to Prologin" %}</h2>

--- a/prologin/pages/templates/pages/about-organization.html
+++ b/prologin/pages/templates/pages/about-organization.html
@@ -97,22 +97,22 @@ with us!</p>
 {% url 'pages:about-organization' as about_organization %}
 
 <h2 id="gcc">{% trans "Girls Can Code!" %}</h2>
-{% blocktrans %}<p class="text-justify">In 2014, Prologin started to organize the Girls Can Code! summer camps.
+<p class="text-justify">{% blocktrans %}In 2014, Prologin started to organize the Girls Can Code! summer camps.
 These training camps are the perfect occasion for young girls who are still in middle school or in high school 
 to discover multiple computer science subjects throughout the week. They will learn how to solve problems with 
 algorithms, explore various computer science topics such as network, web development, robotics, microcontrollers, video games 
-and more through practical exercises.</p>
+and more through practical exercises.{% endblocktrans %}</p>
 
-<p class="text-justify">Conferences from exterior speakers are organized for every camp. It enables the attendees 
+<p class="text-justify">{% blocktrans %}Conferences from exterior speakers are organized for every camp. It enables the attendees 
 to exchange with women working in the computer science industry or in academia. The young girls are sometimes 
 unsure as to what they want to do, this is a golden occasion for them to discuss their education with the speaker, 
-thus helping them for future orientation choices.</p>
+thus helping them for future orientation choices.{% endblocktrans %}</p>
 
-<p class="text-justify">Prologin staff is present during the camp to help them debug their programs and pass on 
-knowledge in computer science and programming.</p>
+<p class="text-justify">{% blocktrans %}Prologin staff is present during the camp to help them debug their programs and pass on 
+knowledge in computer science and programming.{% endblocktrans %}</p>
 
-<p class="text-justify">More information can be found on <a href="https://gcc.prologin.org">Girls Can Code! website</a>. For any 
-inquiries, please <a href="{{ about_organization }}#contact">contact us</a>.</p>{% endblocktrans %}
+<p class="text-justify">{% blocktrans %}More information can be found on <a href="https://gcc.prologin.org">Girls Can Code! website</a>. For any 
+inquiries, please <a href="{{ about_organization }}#contact">contact us</a>.{% endblocktrans %}</p>
 
   <h2 id="contribute">{% trans "Everyone can contribute to Prologin" %}</h2>
   {# TODO: link to forums; link to how to promote (posters) #}

--- a/prologin/pages/templates/pages/about-organization.html
+++ b/prologin/pages/templates/pages/about-organization.html
@@ -109,7 +109,9 @@ unsure as to what they want to do, this is a golden occasion for them to discuss
 backgrounds, thus helping them for their orientation.</p>
 
 <p class="text-justify">Prologin's members are present during the camp to accompany them and to help them debug their 
-programs. More information can be found on Girls Can Code! <a href="https://gcc.prologin.org">website</a>.<br />For any 
+programs and to help them understand key principles in computer science and programming.</p>
+
+<p class⁼"text-justify">More information can be found on Girls Can Code! <a href="https://gcc.prologin.org">website</a>. For any 
 inquiries, please contact us <a href="{{ about_organization }}#contact">here</a>.</p>{% endblocktrans %}
 
   <h2 id="contribute">{% trans "Everyone can contribute to Prologin" %}</h2>


### PR DESCRIPTION
Closes #250 

Hello,

This PR simply adds a Girls Can Code! description with a link to the Girls Can Code! website on the `about-organization` page.

Feel free to update, correct or improve the description if needed.

Thanks in advance for your reviews.