### PR TITLE
problems-url: removing unused url from urls.py causing a 500 error

### DIFF
--- a/prologin/prologin/urls.py
+++ b/prologin/prologin/urls.py
@@ -51,7 +51,6 @@ urlpatterns = [
     path('archives/', include('archives.urls', namespace='archives')),
 
     # Contest
-    path('contest/<int:year>/qualification/problems/', include('problems.urls', namespace='qcm-problems')),
     path('contest/<int:year>/qualification/quiz/', include('qcm.urls', namespace='qcm')),
     path('contest/', include('contest.urls', namespace='contest')),
 


### PR DESCRIPTION
Hello,

This PR will fix an error 500.
It occurred when going to /contest/<year>/qualification/problems, this URL points to the same URL as /train, there is therefore no point in keeping it.

Thank you.