### PR TITLE
Gdpr display on profile for non superuser staff

### DIFF
--- a/prologin/prologin/urls.py
+++ b/prologin/prologin/urls.py
@@ -51,7 +51,6 @@ urlpatterns = [
     path('archives/', include('archives.urls', namespace='archives')),
 
     # Contest
-    path('contest/<int:year>/qualification/problems/', include('problems.urls', namespace='qcm-problems')),
     path('contest/<int:year>/qualification/quiz/', include('qcm.urls', namespace='qcm')),
     path('contest/', include('contest.urls', namespace='contest')),
 

--- a/prologin/users/templates/users/profile.html
+++ b/prologin/users/templates/users/profile.html
@@ -175,7 +175,8 @@
 
   </div>
 
-  {% if shown_user.id == user.id or see_private %}
+  {% has_perm 'users.takeout' user shown_user as can_takeout %}
+  {% if can_takeout %}
   <div class="panel panel-info" style="margin-top: 1em">
     <div class="panel-heading">
       <h3 class="panel-title"> {% trans "Account management" %}</h3>


### PR DESCRIPTION
Fixes #212 

Hello,

This PR will remove access for non superuser staff for the GDPR section in a user's profile.
Please note that the user will still be able to access it, and the site's superusers too.

Thank you.