### PR TITLE
correction-presence: fixing zadd function with "new" prototype and .error obsolete js

### DIFF
--- a/prologin/contest/staff_views.py
+++ b/prologin/contest/staff_views.py
@@ -376,7 +376,7 @@ class ContestantLiveUpdate(CanCorrectPermissionMixin, EditionMixin, DetailView):
             key = settings.CORRECTION_LIVE_UPDATE_REDIS_KEY.format(key=contestant.pk)
             client = StrictRedis(**settings.PROLOGIN_UTILITY_REDIS_STORE)
             client.expire(key, timeout * 2)  # garbage collect the whole set after a bit if no further updates
-            client.zadd(key, now, self_pk)  # add self to the set
+            client.zadd(key, {self_pk: now})  # add self to the set
             members = client.zrangebyscore(key, moments_ago, '+inf')  # list people that are recent enough
             members = set(int(pk) for pk in members) - {self_pk}  # exclude self
             online_users.extend(User.objects.filter(pk__in=members).order_by('pk'))

--- a/prologin/contest/templates/correction/contestant-base.html
+++ b/prologin/contest/templates/correction/contestant-base.html
@@ -203,7 +203,7 @@
             }
             setTimeout(poll_update, delay);
           })
-          .error(function (e) {
+          .fail(function (e) {
             var delay = 1000 * Math.pow(2, ++failures);
             console.warn("Polling failed, waiting", delay);
             setTimeout(poll_update, delay);


### PR DESCRIPTION
Fixes #254 

Hello,

This PR fixes the presence service on the correction page.
The function zadd has changed, instead of having : zadd(name, data, score), we now have zadd(name, {data: score}).
I first thought the error was in the JS, and after looking at the web console, I found that we were still using the .error function instead of the .fail one, so I changed that.

I have tested it locally, it now shows when 2 people are on the same contestant.
I have not tested with more.
When a staff members changes a value (by saving it), it now appears on the others screen.

Thank you.