### PR TITLE
Forum delete url

### DIFF
--- a/prologin/forum/models.py
+++ b/prologin/forum/models.py
@@ -270,11 +270,12 @@ class Post(ExportModelOperationsMixin('post'), models.Model):
     def get_permalink(self):
         return reverse('forum:post', kwargs={'thread_slug': self.thread.slug, 'pk': self.pk})
 
-    def delete(self, using=None):
+    def delete(self, **kwargs):
         if self.is_thread_head:
-            self.thread.delete(using)
-        else:
-            super().delete(using)
+            # A thread with its original first post deleted makes no sense, so delete
+            # the thread itself when its first (head) post is deleted.
+            return self.thread.delete(**kwargs)
+        return super().delete(**kwargs)
 
 
 class ReadState(models.Model):

--- a/prologin/forum/models.py
+++ b/prologin/forum/models.py
@@ -270,6 +270,12 @@ class Post(ExportModelOperationsMixin('post'), models.Model):
     def get_permalink(self):
         return reverse('forum:post', kwargs={'thread_slug': self.thread.slug, 'pk': self.pk})
 
+    def delete(self, using=None):
+        if self.is_thread_head:
+            self.thread.delete(using)
+        else:
+            super().delete(using)
+
 
 class ReadState(models.Model):
     thread = models.ForeignKey(Thread, related_name='read_states',

--- a/prologin/forum/tests.py
+++ b/prologin/forum/tests.py
@@ -41,8 +41,7 @@ class ForumAnonymousTestCase(ForumSetupMixin, TestCase):
 
     def testWrongSlugRedirect(self):
         page = self.client.get(f"/forum/forum-wrong-slug-1/thread-wrong-slug-{self.t11.pk}/")
-        self.assertEqual(page.status_code, 302)
-        self.assertEqual(page.get("Location"), f"/forum/test-forum-1/tout-est-casse-{self.t11.pk}/")
+        self.assertRedirects(page, f"/forum/test-forum-1/tout-est-casse-{self.t11.pk}/")
 
     def testListThreads(self):
         page = self.client.get("/forum/test-forum-1")
@@ -106,8 +105,7 @@ class ForumStaffTestCase(ForumSetupMixin, TestCase):
         self.assertContains(page, "Tout est cassé")
         self.assertContains(page, "marchand")
         page = self.client.post(f"/forum/post/tout-est-casse/{self.p112.pk}/delete")
-        self.assertEqual(page.status_code, 302)
-        self.assertEqual(page.get("Location"), f"/forum/test-forum-1/tout-est-casse-{self.t11.pk}/")
+        self.assertRedirects(page, f"/forum/test-forum-1/tout-est-casse-{self.t11.pk}/")
 
     def testDeleteHeadPost(self):
         page = self.client.get(f"/forum/post/tout-est-casse/{self.p111.pk}/delete")
@@ -117,7 +115,6 @@ class ForumStaffTestCase(ForumSetupMixin, TestCase):
         page = self.client.post(f"/forum/post/tout-est-casse/{self.p111.pk}/delete")
         self.assertEqual(page.status_code, 302)
         url = f"/forum/test-forum-1/tout-est-casse-{self.t11.pk}/"
-        self.assertEqual(page.get("Location"), url)
-        # FIXME: should redirect to the forum instead of the deleted thread!
+        self.assertRedirects(page, "/forum/test-forum-1")
         page = self.client.get(url)
         self.assertEqual(page.status_code, 404)

--- a/prologin/forum/tests.py
+++ b/prologin/forum/tests.py
@@ -114,7 +114,6 @@ class ForumStaffTestCase(ForumSetupMixin, TestCase):
         self.assertContains(page, "joseph")
         page = self.client.post(f"/forum/post/tout-est-casse/{self.p111.pk}/delete")
         self.assertEqual(page.status_code, 302)
-        url = f"/forum/test-forum-1/tout-est-casse-{self.t11.pk}/"
         self.assertRedirects(page, "/forum/test-forum-1")
-        page = self.client.get(url)
+        page = self.client.get(f"/forum/test-forum-1/tout-est-casse-{self.t11.pk}/")
         self.assertEqual(page.status_code, 404)

--- a/prologin/forum/views.py
+++ b/prologin/forum/views.py
@@ -300,8 +300,8 @@ class DeletePostView(PermissionRequiredMixin, DeleteView):
     context_object_name = 'post'
 
     def get_success_url(self):
-        # there is only one post remaining or it's the thread head
-        if self.object.thread.post_count == 1 or self.object.is_thread_head:
+        # it's the thread head, so when deleted, we redirect to the forum URL
+        if self.object.is_thread_head:
             return self.object.thread.forum.get_absolute_url()
         return self.object.thread.get_absolute_url()
 

--- a/prologin/forum/views.py
+++ b/prologin/forum/views.py
@@ -300,7 +300,10 @@ class DeletePostView(PermissionRequiredMixin, DeleteView):
     context_object_name = 'post'
 
     def get_success_url(self):
-        return self.object.thread.forum.get_absolute_url()
+        # there is only one post remaining or it's the thread head
+        if self.object.thread.post_count == 1 or self.object.is_thread_head:
+            return self.object.thread.forum.get_absolute_url()
+        return self.object.thread.get_absolute_url()
 
     def delete(self, request, *args, **kwargs):
         messages.success(request, _("The post was deleted successfully."))

--- a/prologin/forum/views.py
+++ b/prologin/forum/views.py
@@ -300,7 +300,7 @@ class DeletePostView(PermissionRequiredMixin, DeleteView):
     context_object_name = 'post'
 
     def get_success_url(self):
-        return self.object.thread.get_absolute_url()
+        return self.object.thread.forum.get_absolute_url()
 
     def delete(self, request, *args, **kwargs):
         messages.success(request, _("The post was deleted successfully."))


### PR DESCRIPTION
Fixes #197 

Hello,

This PR changes the success URL after deleting a thread, which is no longer the thread's, but rather the forum's itself to prevent a 404 error for the user.

Thank you.