### PR TITLE
qcm: allow staff to complete the qcm and remove the correction display

### DIFF
--- a/prologin/qcm/views.py
+++ b/prologin/qcm/views.py
@@ -50,13 +50,6 @@ class DisplayQCMView(PermissionRequiredMixin, UpdateView):
         except self.model.DoesNotExist:
             raise Http404()
 
-    def post(self, request, *args, **kwargs):
-        self.object = self.get_object()
-        if self.can_view_correction:
-            # just display the form so we can show right/wrong answers
-            return self.form_invalid(self.get_form())
-        return super().post(request, *args, **kwargs)
-
     def form_valid(self, form):
         if not self.can_save_answers:
             # bypasses form.save(), just redirects


### PR DESCRIPTION
Fixes #152 

Hello,

This PR simply removes the overridden post method in the qcm view.
This allows the superusers to complete the qcm themselves, and prevents the correction from displaying.
However, this means that people can now submit past qcm, and don't have the answers displayed on the form (they are are given when the qualifications are over though, in the archives). Are we OK with this ?

Thank you.