### PR TITLE
increase size limit at compile time to 20Mo

### DIFF
--- a/prologin/problems/models/submission.py
+++ b/prologin/problems/models/submission.py
@@ -278,7 +278,7 @@ class SubmissionCode(ExportModelOperationsMixin('submission_code'), models.Model
             'compile': {'mem': int(1e7),
                         'time': 20,
                         'wall-time': 60,
-                        'fsize': 4000},
+                        'fsize': 20000},
             'tests': list(build_tests()),
         }
         return request


### PR DESCRIPTION
Previous limit (4Mo) was a bit tight for Rust (we observed that an empty code could generate a 7Mo binary on some setups).