### PR TITLE
Add color to optional question in the mcq when correcting

### DIFF
--- a/prologin/contest/templates/correction/contestant-qualification.html
+++ b/prologin/contest/templates/correction/contestant-qualification.html
@@ -23,7 +23,11 @@
     <ol class="mainlist qcm">
       {% for field in quiz_form %}
         {% with question=field.field.question %}
-          <li class="question">
+          <li class="question
+            {% if question.is_optional %}
+              optional
+            {% endif %}
+          ">
             <div class="body">
               <div class="main">{{ question.body|markdown:0 }}</div>
               {% if question.verbose %}

--- a/prologin/qcm/static/qcm/qcm.css
+++ b/prologin/qcm/static/qcm/qcm.css
@@ -95,3 +95,7 @@ ol.mainlist > li:after {
   line-height: 0;
   height: 0;
 }
+
+.optional::before {
+  color: orange !important;
+}


### PR DESCRIPTION
Change the color of question number if this question is marked as optional.
This is only showing the color when correcting the mcq.

The color is orange. Another color can be better.

![image](https://user-images.githubusercontent.com/11708575/107443938-00c33380-6b3a-11eb-9160-047c98d38786.png)
