### PR TITLE
add: countdown until the 2021 qualifications

### DIFF
--- a/prologin/homepage/templates/homepage/countdown.html
+++ b/prologin/homepage/templates/homepage/countdown.html
@@ -1,0 +1,56 @@
+{% load i18n %}
+
+<ul class="row countdown">
+  <li class="col-sm-3"><span id="countdown-days">1</span> {% trans "days" %}</li>
+  <li class="col-sm-3"><span id="countdown-hours">1</span> {% trans "hours" %}</li>
+  <li class="col-sm-3"><span id="countdown-minutes">1</span> {% trans "minutes" %}</li>
+  <li class="col-sm-3"><span id="countdown-seconds">1</span> {% trans "seconds" %}</li>
+</ul>
+
+<style>
+.countdown {
+  text-align: center;
+  display: none;
+}
+
+.countdown li {
+  display: inline-block;
+  font-size: 1.5em;
+  list-style-type: none;
+  padding: 1em;
+  text-transform: uppercase;
+}
+
+.countdown li span {
+  display: block;
+  font-size: 4.5rem;
+}
+</style>
+
+<script>
+const second = 1000,
+      minute = second * 60,
+      hour = minute * 60,
+      day = hour * 24;
+
+let countDown = Date.UTC(2021, 10, 15, 14, 42, 00),
+    x = setInterval(function() {    
+      let now = new Date().getTime(),
+          distance = countDown - now;
+
+      if (distance < 0) {
+        for (let countdown of document.querySelectorAll(".countdown")) {
+          countdown.style.display = "none";
+        }
+        clearInterval(x);
+      } else {
+        for (let countdown of document.querySelectorAll(".countdown")) {
+          countdown.style.display = "block";
+        }
+        document.getElementById("countdown-days").innerText = Math.floor(distance / (day));
+        document.getElementById("countdown-hours").innerText = Math.floor((distance % (day)) / (hour));
+        document.getElementById("countdown-minutes").innerText = Math.floor((distance % (hour)) / (minute));
+        document.getElementById("countdown-seconds").innerText = Math.floor((distance % (minute)) / second);
+      }
+  }, 1000)
+</script>

--- a/prologin/homepage/templates/homepage/countdown.html
+++ b/prologin/homepage/templates/homepage/countdown.html
@@ -1,20 +1,21 @@
 {% load i18n %}
 
 <ul class="row countdown">
-  <li class="col-sm-3"><span id="countdown-days">1</span> {% trans "days" %}</li>
-  <li class="col-sm-3"><span id="countdown-hours">1</span> {% trans "hours" %}</li>
-  <li class="col-sm-3"><span id="countdown-minutes">1</span> {% trans "minutes" %}</li>
-  <li class="col-sm-3"><span id="countdown-seconds">1</span> {% trans "seconds" %}</li>
+  <li class="col-xs-3 col-sm-3"><span id="countdown-days">1</span> {% trans "days" %}</li>
+  <li class="col-xs-3 col-sm-3"><span id="countdown-hours">1</span> {% trans "hours" %}</li>
+  <li class="col-xs-3 col-sm-3"><span id="countdown-minutes">1</span> {% trans "minutes" %}</li>
+  <li class="col-xs-3 col-sm-3"><span id="countdown-seconds">1</span> {% trans "seconds" %}</li>
 </ul>
 
 <style>
 .countdown {
   text-align: center;
+  padding-left: 0px;
 }
 
 .countdown li {
   display: inline-block;
-  font-size: 1.5em;
+  font-size: 1rem;
   list-style-type: none;
   padding: 1em;
   text-transform: uppercase;
@@ -22,7 +23,17 @@
 
 .countdown li span {
   display: block;
-  font-size: 4.5rem;
+  font-size: 3rem;
+}
+
+@media (min-width: 768px) {
+  .countdown li {
+    font-size: 1.5em;
+  }
+
+  .countdown li span {
+    font-size: 4.5rem;
+  }
 }
 </style>
 
@@ -58,7 +69,10 @@
   update_countdown();
   let intervalId = setInterval(() => {
     update_countdown(
-      () => clearInterval(intervalId)
+        () => {
+            document.location.reload();
+            clearInterval(intervalId);
+        }
     );
   }, 1000);
 })();

--- a/prologin/homepage/templates/homepage/countdown.html
+++ b/prologin/homepage/templates/homepage/countdown.html
@@ -10,7 +10,6 @@
 <style>
 .countdown {
   text-align: center;
-  display: none;
 }
 
 .countdown li {
@@ -28,30 +27,40 @@
 </style>
 
 <script>
-const second = 1000,
-      minute = second * 60,
-      hour = minute * 60,
-      day = hour * 24;
+(() => {
+  const second = 1000,
+        minute = second * 60,
+        hour = minute * 60,
+        day = hour * 24;
 
-let countDown = Date.UTC(2021, 9 /* 9 is october */, 15, 14, 42, 00),
-    x = setInterval(function() {    
-      let now = new Date().getTime(),
-          distance = countDown - now;
+  let target_date = Date.UTC(2021, 9 /* 9 is october */, 15, 14, 42, 00),
+      countdown_container = document.querySelector(".countdown"),
+      days_span = document.getElementById("countdown-days"),
+      hours_span = document.getElementById("countdown-hours"),
+      minutes_span = document.getElementById("countdown-minutes"),
+      seconds_span = document.getElementById("countdown-seconds");
 
-      if (distance < 0) {
-        for (let countdown of document.querySelectorAll(".countdown")) {
-          countdown.style.display = "none";
-        }
-        clearInterval(x);
-      } else {
-        for (let countdown of document.querySelectorAll(".countdown")) {
-          countdown.style.display = "block";
-        }
-        document.getElementById("countdown-days").innerText = Math.floor(distance / (day));
-        document.getElementById("countdown-hours").innerText = Math.floor((distance % (day)) / (hour));
-        document.getElementById("countdown-minutes").innerText = Math.floor((distance % (hour)) / (minute));
-        document.getElementById("countdown-seconds").innerText = Math.floor((distance % (minute)) / second);
-      }
-  }, 1000)
+  let update_countdown = (callback) => {
+    let now = new Date().getTime(),
+        distance = target_date - now;
+
+    if (distance < 0) {
+      countdown_container.style.display = "none";
+      if (callback) callback();
+    } else {
+      days_span.innerText = Math.floor(distance / (day));
+      hours_span.innerText = Math.floor((distance % (day)) / (hour));
+      minutes_span.innerText = Math.floor((distance % (hour)) / (minute));
+      seconds_span.innerText = Math.floor((distance % (minute)) / second);
+    }
+  }
+
+  update_countdown();
+  let intervalId = setInterval(() => {
+    update_countdown(
+      () => clearInterval(intervalId)
+    );
+  }, 1000);
+})();
 </script>
 

--- a/prologin/homepage/templates/homepage/countdown.html
+++ b/prologin/homepage/templates/homepage/countdown.html
@@ -33,7 +33,7 @@
         hour = minute * 60,
         day = hour * 24;
 
-  let target_date = Date.UTC(2021, 9 /* 9 is october */, 15, 14, 42, 00),
+    let target_date = new Date({{ countdown_timestamp }}),
       countdown_container = document.querySelector(".countdown"),
       days_span = document.getElementById("countdown-days"),
       hours_span = document.getElementById("countdown-hours"),

--- a/prologin/homepage/templates/homepage/countdown.html
+++ b/prologin/homepage/templates/homepage/countdown.html
@@ -33,7 +33,7 @@ const second = 1000,
       hour = minute * 60,
       day = hour * 24;
 
-let countDown = Date.UTC(2021, 10, 15, 14, 42, 00),
+let countDown = Date.UTC(2021, 9 /* 9 is october */, 15, 14, 42, 00),
     x = setInterval(function() {    
       let now = new Date().getTime(),
           distance = countDown - now;
@@ -54,3 +54,4 @@ let countDown = Date.UTC(2021, 10, 15, 14, 42, 00),
       }
   }, 1000)
 </script>
+

--- a/prologin/homepage/templates/homepage/jumbotron.html
+++ b/prologin/homepage/templates/homepage/jumbotron.html
@@ -6,6 +6,8 @@
     <h1>{% trans "Prologin, the French National Computer Science Contest" %}</h1>
     <p>{% blocktrans with born_year as born_year %}Born in {{ born_year }} or after? Join the Prologin contest! Registration is free.{% endblocktrans %}</p>
 
+    {% include "homepage/countdown.html" %}
+
     {% trans "Unknown date" as no_such_date %}
     {# timeline #}
     <div class="htl">

--- a/prologin/homepage/templates/homepage/jumbotron.html
+++ b/prologin/homepage/templates/homepage/jumbotron.html
@@ -5,8 +5,10 @@
 
     <h1>{% trans "Prologin, the French National Computer Science Contest" %}</h1>
     <p>{% blocktrans with born_year as born_year %}Born in {{ born_year }} or after? Join the Prologin contest! Registration is free.{% endblocktrans %}</p>
-
-    {% include "homepage/countdown.html" %}
+    
+    {% if countdown_enabled %}
+      {% include "homepage/countdown.html" %}
+    {% endif %}
 
     {% trans "Unknown date" as no_such_date %}
     {# timeline #}

--- a/prologin/homepage/views.py
+++ b/prologin/homepage/views.py
@@ -45,6 +45,7 @@ class HomepageView(TemplateView):
         context['problems_count'] = problems_count
         context['problems_completed'] = problems_completed
         context['born_year'] = settings.PROLOGIN_EDITION - settings.PROLOGIN_MAX_AGE
+        context['countdown_enabled'] = settings.COUNTDOWN_ENABLED
         context['articles'] = articles
         sponsors = list(sponsor.models.Sponsor.active.all())
         random.shuffle(sponsors)

--- a/prologin/homepage/views.py
+++ b/prologin/homepage/views.py
@@ -1,4 +1,5 @@
 import random
+import datetime
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist, ImproperlyConfigured
 from django.views.generic import TemplateView
@@ -45,7 +46,17 @@ class HomepageView(TemplateView):
         context['problems_count'] = problems_count
         context['problems_completed'] = problems_completed
         context['born_year'] = settings.PROLOGIN_EDITION - settings.PROLOGIN_MAX_AGE
-        context['countdown_enabled'] = settings.COUNTDOWN_ENABLED
+
+        now = datetime.datetime.now(settings.PROLOGIN_HOMEPAGE_COUNTDOWN_TZ)
+        context['countdown_target'] = settings.PROLOGIN_HOMEPAGE_COUNTDOWN
+        context['countdown_enabled'] = \
+            context['countdown_target'] is not None \
+            and context['countdown_target'] > now
+        if context['countdown_enabled']:
+            # JavaScript timestamps are in milliseconds
+            context['countdown_timestamp'] = 1000 * \
+                int(settings.PROLOGIN_HOMEPAGE_COUNTDOWN.timestamp())
+
         context['articles'] = articles
         sponsors = list(sponsor.models.Sponsor.active.all())
         random.shuffle(sponsors)

--- a/prologin/locale/fr/LC_MESSAGES/django.po
+++ b/prologin/locale/fr/LC_MESSAGES/django.po
@@ -28,7 +28,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Prologin website\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-10-13 12:31+0200\n"
+"POT-Creation-Date: 2021-10-13 12:33+0200\n"
 "PO-Revision-Date: 2020-05-10 18:14+0000\n"
 "Last-Translator: Valentin Seux <valentin.seux@prologin.org>\n"
 "Language-Team: French (http://www.transifex.com/prologin/prologin-site/"
@@ -2073,6 +2073,22 @@ msgstr "Le sujet a été déplacé avec succès."
 msgid "The thread was deleted successfully."
 msgstr "Le sujet a été supprimé avec succès."
 
+#: homepage/templates/homepage/countdown.html:4
+msgid "days"
+msgstr ""
+
+#: homepage/templates/homepage/countdown.html:5
+msgid "hours"
+msgstr ""
+
+#: homepage/templates/homepage/countdown.html:6
+msgid "minutes"
+msgstr ""
+
+#: homepage/templates/homepage/countdown.html:7
+msgid "seconds"
+msgstr ""
+
 #: homepage/templates/homepage/homepage.html:5
 #: homepage/templates/homepage/jumbotron.html:6
 #: prologin/templates/prologin/base.html:35
@@ -2171,7 +2187,7 @@ msgstr ""
 "Vous êtes né en %(born_year)s ou après&nbsp;? Participez à Prologin&nbsp;! "
 "L'inscription est gratuite."
 
-#: homepage/templates/homepage/jumbotron.html:9
+#: homepage/templates/homepage/jumbotron.html:13
 msgid "Unknown date"
 msgstr "Date inconnue"
 

--- a/prologin/prologin/settings/common.py
+++ b/prologin/prologin/settings/common.py
@@ -407,6 +407,6 @@ OIDC_AFTER_USERLOGIN_HOOK = 'oidc_policy.oidc_authz.authorize'
 
 # Countdown target date (None to disable)
 PROLOGIN_HOMEPAGE_COUNTDOWN_TZ = datetime.timezone(datetime.timedelta(hours=2))
-PROLOGIN_HOMEPAGE_COUNTDOWN = datetime.datetime(2021, 10, 15, 12, 42, 00, tzinfo=PROLOGIN_HOMEPAGE_COUNTDOWN_TZ)
+PROLOGIN_HOMEPAGE_COUNTDOWN = datetime.datetime(2021, 10, 15, 16, 42, 00, tzinfo=PROLOGIN_HOMEPAGE_COUNTDOWN_TZ)
 #PROLOGIN_HOMEPAGE_COUNTDOWN = None
 

--- a/prologin/prologin/settings/common.py
+++ b/prologin/prologin/settings/common.py
@@ -404,3 +404,9 @@ FACEBOOK_GRAPH_API_ACCESS_TOKEN = ""
 # Django OpenID Connect Provider
 OIDC_EXTRA_SCOPE_CLAIMS = 'oidc_policy.oidc_scopes.ProloginScopeClaims'
 OIDC_AFTER_USERLOGIN_HOOK = 'oidc_policy.oidc_authz.authorize'
+
+# Countdown target date (None to disable)
+PROLOGIN_HOMEPAGE_COUNTDOWN_TZ = datetime.timezone(datetime.timedelta(hours=2))
+PROLOGIN_HOMEPAGE_COUNTDOWN = datetime.datetime(2021, 10, 15, 12, 42, 00, tzinfo=PROLOGIN_HOMEPAGE_COUNTDOWN_TZ)
+#PROLOGIN_HOMEPAGE_COUNTDOWN = None
+

--- a/prologin/prologin/settings/conf.sample.py
+++ b/prologin/prologin/settings/conf.sample.py
@@ -75,6 +75,3 @@ EMAIL_USE_SSL = False
 RECAPTCHA_PUBLIC_KEY = ''
 RECAPTCHA_PRIVATE_KEY = ''
 
-# Enable / disable the countdown
-COUNTDOWN_ENABLED = True
-

--- a/prologin/prologin/settings/conf.sample.py
+++ b/prologin/prologin/settings/conf.sample.py
@@ -74,3 +74,7 @@ EMAIL_USE_SSL = False
 
 RECAPTCHA_PUBLIC_KEY = ''
 RECAPTCHA_PRIVATE_KEY = ''
+
+# Enable / disable the countdown
+COUNTDOWN_ENABLED = True
+


### PR DESCRIPTION
This adds a countdown until 2021-10-15 16:42:00 GMT+2 on the homepage.

Some features it still misses:
  - [x] allow some kind of setting to disable the countdown template