### PR TITLE
Only display a sponsor's logo if it exists in /sponsors

### DIFF
--- a/prologin/sponsor/templates/sponsor/index.html
+++ b/prologin/sponsor/templates/sponsor/index.html
@@ -45,12 +45,14 @@
             <div class="col-md-4">
               <div class="panel">
           {% endif %}
+            {% if sponsor.logo %}
               <div class="panel-body">
                 <a class="spons-logo" href="{{ sponsor.site }}">
                   <img alt="{{ sponsor.name }}" src="{{ sponsor.logo.url }}" >
                 </a>
               </div>
             </div>
+            {% endif %}
             {% if type == "Gold" %}
               <div class="col-sm-6 col-md-9">
                 <p><strong>{{ sponsor.name }}</strong></p>


### PR DESCRIPTION
Simple condition to check if a sponsor has a logo before trying to display it, preventing a crash on `/sponsors`.

Resolves #352 
