### PR TITLE
contest: fix broken event wish order

### DIFF
--- a/prologin/contest/admin.py
+++ b/prologin/contest/admin.py
@@ -1,4 +1,4 @@
-from adminsortable.admin import NonSortableParentAdmin, SortableStackedInline
+from adminsortable.admin import NonSortableParentAdmin
 from django import forms
 from django.contrib import admin
 from django.contrib.contenttypes.models import ContentType
@@ -6,15 +6,6 @@ from django.http import HttpResponseRedirect
 from django.utils.translation import ugettext_lazy as _
 import contest.models
 from prologin.utils import admin_url_for
-
-
-class EventWishesFormSet(forms.BaseInlineFormSet):
-    def _construct_form(self, i, **kwargs):
-        form = super()._construct_form(i, **kwargs)
-        qs = form.fields['event'].queryset
-        form.fields['event'].queryset = qs.filter(type=contest.models.Event.Type.semifinal.value,
-                                                  edition=self.instance.edition)
-        return form
 
 
 class ContestantForm(forms.ModelForm):
@@ -31,11 +22,10 @@ class EventInline(admin.StackedInline):
     extra = 1
 
 
-class EventWishesInline(SortableStackedInline):
-    # FIXME: event queryset repeated N times
+class EventWishesInline(admin.StackedInline):
     model = contest.models.EventWish
-    extra = 1
-    formset = EventWishesFormSet
+    extra = 0
+    fields = ('event', 'order')
 
 
 class CorrectionInline(admin.StackedInline):

--- a/prologin/contest/models.py
+++ b/prologin/contest/models.py
@@ -538,10 +538,10 @@ class Contestant(ExportModelOperationsMixin('contestant'), models.Model):
         return "{edition}: {user}".format(user=self.user, edition=self.edition)
 
 
-class EventWish(ExportModelOperationsMixin('event_wish'), SortableMixin):
+class EventWish(ExportModelOperationsMixin('event_wish'), models.Model):
     contestant = models.ForeignKey(Contestant, on_delete=models.CASCADE)
     event = models.ForeignKey(Event, on_delete=models.CASCADE)
-    order = models.IntegerField(editable=False, db_index=True)
+    order = models.IntegerField(db_index=True)
 
     class Meta:
         ordering = ('order',)


### PR DESCRIPTION
adminsortable's SortableMixin was trafficking the order of event wishes
before the save as a result, two event wished could have the same order
(i.e 1, 1, 2). Now the order of the wishes are (0, 1, 2).

Removed the admin sortable from contest eventwish as it is no longer
maintained. Instead use raw order field to modify event wish order in
django admin.