### PR TITLE
archives: rename "Regional events report"

### DIFF
--- a/prologin/archives/templates/archives/index.html
+++ b/prologin/archives/templates/archives/index.html
@@ -64,7 +64,7 @@
             {% if archive.semifinal.populated %}
               <ul class="nav">
               {% if archive.semifinal.content %}
-                <li><a href="{% url 'archives:report' archive.year 'semifinal' %}"><i class="fa fa-fw fa-bullhorn"></i> {% trans "Regional events report" %}</a></li>
+                <li><a href="{% url 'archives:report' archive.year 'semifinal' %}"><i class="fa fa-fw fa-bullhorn"></i> {% trans "Written test" %}</a></li>
               {% endif %}
               {% if archive.semifinal.challenge %}
                 <li><a href="{% url 'problems:challenge' archive.semifinal.challenge.year archive.semifinal.challenge.event_type.name %}"><i class="fa fa-fw fa-pencil"></i> {% blocktrans count archive.semifinal.challenge.problems|length as count %}{{ count }} problem{% plural %}{{ count }} problems{% endblocktrans %}</a></li>


### PR DESCRIPTION
This fixes #343.

#### TODO:
- [ ] translating on Transifex `"Written test"` as `"Épreuves écrites"`