### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Clone the website and the other Prologin repositories needed for the different
 modules of the website:
 
 ```bash
-git clone git@github.com:prologin/site
+git clone git@github.com:prologin/concours-site
 git clone git@github.com:prologin/problems   # Training exercises (private)
 git clone git@github.com:prologin/archives   # Edition archives (private)
 git clone git@github.com:prologin/documents  # Admin. documents (private)


### PR DESCRIPTION
Fixed url of own repo in README. Repo is now called 'concours-site', not just 'site'.